### PR TITLE
add prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1",
   "description": "A react component that loads sprite image and the runs it as an animation",
   "main": "lib/index.js",
+  "private": true,
   "scripts": {
     "test": "eslint ./src && eslint ./test && npm run compile && browserify test/*.js | tape-run",
     "compile": "babel src --stage 0 --modules common --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "browserify": "^14.3.0",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^7.0.0",
+    "prop-types": "^15.5.10",
     "react-addons-test-utils": "^15.0.1",
     "tape": "^4.4.0",
     "tape-run": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.1",
   "description": "A react component that loads sprite image and the runs it as an animation",
   "main": "lib/index.js",
-  "private": true,
   "scripts": {
     "test": "eslint ./src && eslint ./test && npm run compile && browserify test/*.js | tape-run",
     "compile": "babel src --stage 0 --modules common --out-dir lib",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const React = require('react')
-const {PropTypes, Component} = React
+const {Component} = React
+var PropTypes = require('prop-types')
 const raf = require('raf')
 const noop = () => {}
 const propTypes = {


### PR DESCRIPTION
Fixes "Warning: Accessing PropTypes via the main React package is deprecated."