### PR TITLE
Added unmount check on image load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,9 @@ class SpriteAnimator extends Component {
     const {isLoaded, hasErrored} = this.state
     if (!isLoaded && !hasErrored) {
       SpriteAnimator.loadImage(sprite, (err, image) => {
+        if (this.unmounting) {
+          return
+        }
         if (err) {
           onError(err)
           // dont trigger update


### PR DESCRIPTION
This is a continuing issue on our project displaying the following error message in console:
![image](https://user-images.githubusercontent.com/18641362/33333826-a2499316-d470-11e7-9469-19c697a71f7f.png)

**The issue**: coming from a `setState` used inside an image loaded callback. When the image is not loaded yet and the component is un-mounting (as in our project) the `setState` is called although it should not.
**The Solution**: Added unmount check on image load callback to avoid the setState method, as it is not needed anymore.

P.S: although `this.unmounting` is react anti-pattern i still like the use of it, mainly on this cases. 👍 