### PR TITLE
Take startFrame into account

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,15 +96,15 @@ class SpriteAnimator extends Component {
       return this.loadSprite()
     }
 
-    const {shouldAnimate, fps, stopLastFrame, onEnd} = this.props
+    const {shouldAnimate, fps, stopLastFrame, onEnd, startFrame} = this.props
     if (shouldAnimate) {
       const {maxFrames, currentFrame} = this.state
-      const nextFrame = currentFrame + 1 >= maxFrames ? 0 : currentFrame + 1
+      const nextFrame = currentFrame + 1 >= maxFrames ? startFrame : currentFrame + 1
 
       if (!shouldAnimate) {
         return
       }
-      if (nextFrame === 0 && stopLastFrame) {
+      if (nextFrame === startFrame && stopLastFrame) {
         this.prevTime = 0
         return onEnd()
       }


### PR DESCRIPTION
Closes https://github.com/jcblw/react-sprite-animator/issues/16

Instead of always resetting to 0 once we reach the last frame, the `nextFrame` will be `startFrame`