### PR TITLE
Fix for onEnd callback + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is the same for the hooks options and the props of the component.
 - fps **{number}** - the frame rate (frames per second) target
 - stopLastFrame **{bool}** - stops animation from looping
 - frame **{number}** - manually sets current frame
+- onEnd **{function}** - callback when the animation finishes (only triggered when stopLastFrame is true)
 
 **Only required for two-dimensional sprites**
 

--- a/src/useSprite.js
+++ b/src/useSprite.js
@@ -127,7 +127,7 @@ export const useSprite = ({
       if (!shouldAnimate) {
         return
       }
-      if (nextFrame === startFrame && stopLastFrame) {
+      if (currentFrame === maxFrames - 1 && stopLastFrame) {
         return onEnd()
       }
 

--- a/src/useSprite.spec.js
+++ b/src/useSprite.spec.js
@@ -218,5 +218,37 @@ describe('useSprite hook', () => {
 
       expect(result.current.backgroundPosition).toBe('0px 0px')
     })
+    it('should call onEnd only at the end of an animation', async () => {
+      const width = 36 * 2
+      const height = 36
+      const imageMock = createImageMock({ width, height })
+      const onEnd = jest.fn()
+      const rafMock = createRafMock()
+      renderHook(() =>
+        useSprite({
+          startFrame: 0,
+          sprite: heart,
+          width: 36,
+          height: 36,
+          fps: 1000,
+          stopLastFrame: true,
+          onEnd,
+        })
+      )
+
+      act(() => {
+        imageMock.current.triggerLoad()
+      })
+
+      expect(onEnd).not.toBeCalled()
+
+      act(() => {
+        // step into initial animation set time back
+        rafMock.current.triggerNextAnimationFrame(performance.now() - 5)
+        rafMock.current.triggerNextAnimationFrame(performance.now() + 10)
+      })
+
+      expect(onEnd).toBeCalled()
+    })
   })
 })


### PR DESCRIPTION
Fixed an issue where onEnd was getting triggered on start.
Added onEnd to the Readme documentation.